### PR TITLE
Add variable declaration

### DIFF
--- a/docs/INSTALL-LINK-IOS.md
+++ b/docs/INSTALL-LINK-IOS.md
@@ -57,6 +57,11 @@ BackgroundFetch.scheduleTask({
 The [**`BGTaskScheduler`**](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler?language=objc) API introduced in iOS 13 requires special setup:
 
 ```obj-c
+.
+.
+#import <TSBackgroundFetch/TSBackgroundFetch.h>
+.
+.
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   .
   .


### PR DESCRIPTION
Prevent the following build error: `Use of undeclared identifier 'fetch'`